### PR TITLE
Resolve session names up to seconds

### DIFF
--- a/src/main/java/Main/Session.java
+++ b/src/main/java/Main/Session.java
@@ -45,7 +45,7 @@ public class Session {
 
   static final String WALNUT_VERSION = "7.1.0";
   static final String PROMPT = "\n[Walnut]$ ";
-  private static final String FRIENDLY_DATE_TIME_PATTERN = "yyyy_MM_dd_HH_mm"; // TODO; what about localization?
+  private static final String FRIENDLY_DATE_TIME_PATTERN = "yyyy_MM_dd_HH_mm_ss"; // TODO; what about localization?
 
   private static final String GLOBAL_NAME = "Global";
   private static final String SESSION_NAME = "Session";


### PR DESCRIPTION
This PR changes the session names to include the current seconds as well.

When running multiple input scripts in quick succession, resolving session names only up to minutes may cause conflicts as Walnut would automatically load the old session.